### PR TITLE
Fix: Correct tsconfig.json for alias path resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,9 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    },
     "target": "ES2017",
     "lib": [
       "dom",


### PR DESCRIPTION
- I've added `baseUrl` and `paths` to `compilerOptions` in `tsconfig.json` to ensure that `@/*` path aliases are correctly resolved during the build process.
- This fixes 'Module not found' errors on Vercel for aliased imports like `@/components/ui/carousel` and `@/app/course/[courseId]/flashcards/_components/FlashCardItem`.
- The `jsconfig.json` which previously contained path aliases might have been superseded or ignored due to the presence of `tsconfig.json` with `allowJs` enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved import path handling for easier and cleaner module imports throughout the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->