### PR TITLE
Fix: Resolve Next.js layout type error in app/layout.js

### DIFF
--- a/app/fonts.js
+++ b/app/fonts.js
@@ -1,0 +1,3 @@
+import { Outfit } from "next/font/google";
+
+export const outfit = Outfit({ subsets: ['latin'] });

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,10 +1,9 @@
 import localFont from "next/font/local";
-import {Outfit} from "next/font/google";
 import "./globals.css";
 import { ClerkProvider } from "@clerk/nextjs";
 import Provider from "./Provider";
-import { Toaster } from "@/components/ui/sonner"
-export const outfit=Outfit({subsets:['latin']});
+import { Toaster } from "@/components/ui/sonner";
+import { outfit } from "./fonts";
 
 export const metadata = {
   title: "Create Next App",


### PR DESCRIPTION
- I moved the `Outfit` font definition from `app/layout.js` to a new `app/fonts.js` file.
- I updated `app/layout.js` to import the font from `app/fonts.js`.
- This prevents the `outfit` constant from being an export of `app/layout.js`, resolving the "not a valid Layout export field" error during the Vercel build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated font management to use a centralized configuration for the Outfit font, ensuring consistent font usage across the application. No visible changes to the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->